### PR TITLE
Fix the plugins's description alignment 

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 func getApp() components.App {
 	app := components.App{}
 	app.Name = "cve-impact-check"
-	app.Description = " Using JFrog Xray, easily check if a published CVE has impact over your repositories"
+	app.Description = "Using JFrog Xray, easily check if a published CVE has impact over your repositories"
 	app.Version = "v0.1.0"
 	app.Commands = getCommands()
 	return app


### PR DESCRIPTION
Fix the plugins's description alignment, as it is displayed with JFrog CLI.
See the attached image - 
![image](https://user-images.githubusercontent.com/7830056/151699432-48a389b7-a657-42da-937f-370cb6ad93ce.png)
